### PR TITLE
Grocery List Generation based on User's Meal Plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,45 +4,36 @@ Wireframes: https://drive.google.com/file/d/1FyKvU3DOxkgPq8OdsOVWELTh4LR4OAgK/vi
 
 Features
 
-- [ ] UI
-  - [ ] Interactive UI for picking the ingredients
-  - [ ] Loading state for when data is fetching
-  - [ ] Different pages:
-    - [ ] Home Page
-    - [ ] Fridge page: pick ingredients after logging in
-    - [ ] Recipe page: after picking ingredients
-    - [ ] Profile page: only after logging in
-- [ ] Recipe Generation
-  - [ ] Generated Recipe based on selected ingredients
-  - [ ] Spoonacular API to fetch recipes
-  - [ ] Display detailed recipe information (title, cook time, servings, etc)
-  - [ ] Click the recipe more details will come up (instructions, ingredients, etc)
-  - [ ] If there are no recipes available with only those selected ingredients, recipe generated are those that they can make if they had 1 more ingredient (unsure?)
-- [ ] Filters
-  - [ ] Based on cook time
-  - [ ] Based on serving size
-  - [ ] Based on dietary restrictions (vegetarian, gluten-free, etc)
-  - [ ] Based on nutrition information (calories, carbs, protein, etc)
-- [ ] User System
-  - [ ] User register and login with Express Sessions
-  - [ ] Secure routes so Fridge and Profile pages are only accessible after login
-- [ ] Save Recipes
-  - [ ] Able to save recipes
-  - [ ] Saved recipes are displayed on the profile page
-
-- [ ] Like Recipes
-  - [ ] Able to like recipes
-  - [ ] Like recipes are used for personalization (stretch feature)
+- [x] UI
+  - [x] Interactive UI for picking the ingredients
+  - [x] Loading state for when data is fetching
+  - [x] Different pages:
+    - [x] Home Page
+    - [x] Fridge page: pick ingredients after logging in
+    - [x] Recipe page: after picking ingredients
+    - [x] Recs page: personalized recipes based on liked recipes
+    - [x] Profile page: only after logging in
+- [x] Recipe Generation
+  - [x] Generated Recipe based on selected ingredients
+  - [x] Spoonacular API to fetch recipes
+  - [x] Display detailed recipe information (title, etc)
+  - [x] Click the recipe more details will come up (instructions, ingredients, etc)
+- [x] Filters
+  - [x] Based on cook time
+  - [x] Based on nutrition information (calories, carbs, protein, etc)
+- [x] User System
+  - [x] User register and login with Express Sessions
+  - [x] Secure routes so Fridge and Profile pages are only accessible after login
+- [x] Save Recipes
+  - [x] Able to save recipes
+  - [x] Saved recipes are displayed on the profile page
+- [x] Like Recipes
+  - [x] Able to like recipes
+  - [x] Like recipes are used for personalization in another page (stretch feature)
 
 Stretch Goals
 
-- [ ] Personalized Recommendation
-  - [ ] Future recipes generated are influenced by recipes users have liked
-  - [ ] Look at ingredients overlap, cuisines[], dishTypes[], recipe tags, cooking time to see if there is a pattern
-
-- [ ] Near-Match Recipes
-  - [ ] Shows recipes that the users are missing 1 or 2 ingredient to
-
-- [ ] Dietary Restrictions Information
-  - [ ] Save this information to the user's profile (ex vegetarian, gluten-free)
-  - [ ] Makes sure all the recipes generated automatically has this dietary restriction followed
+- [x] Personalized Recommendation
+  - [x] Future recipes generated are influenced by recipes users have liked
+  - [x] Look at ingredients overlap, cuisines[], dishTypes[], cooking time to see if there is a pattern
+    - currently only looks at ingredients overlap (top 5 most frequent)

--- a/backend/prisma/migrations/20250707174322_add_mealplan/migration.sql
+++ b/backend/prisma/migrations/20250707174322_add_mealplan/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "MealPlan" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "weekStartDate" TIMESTAMP(3) NOT NULL,
+    "plan" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MealPlan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FridgeItem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "unit" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "FridgeItem_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "MealPlan" ADD CONSTRAINT "MealPlan_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FridgeItem" ADD CONSTRAINT "FridgeItem_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250707235055_smart_meal_plan/migration.sql
+++ b/backend/prisma/migrations/20250707235055_smart_meal_plan/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `updatedAt` on the `MealPlan` table. All the data in the column will be lost.
+  - You are about to drop the column `weekStartDate` on the `MealPlan` table. All the data in the column will be lost.
+  - You are about to drop the `FridgeItem` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `weekStart` to the `MealPlan` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "FridgeItem" DROP CONSTRAINT "FridgeItem_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "MealPlan" DROP COLUMN "updatedAt",
+DROP COLUMN "weekStartDate",
+ADD COLUMN     "weekStart" TIMESTAMP(3) NOT NULL;
+
+-- DropTable
+DROP TABLE "FridgeItem";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   password String
   saved Recipe[] @relation("SavedRecipes")
   liked Recipe[] @relation("LikedRecipes")
+  mealPlans MealPlan[]
 }
 
 model Recipe {
@@ -28,4 +29,13 @@ model Recipe {
   ingredients String[] @default([])
   userSaves User[] @relation("SavedRecipes")
   userLikes User[] @relation("LikedRecipes")
+}
+
+model MealPlan {
+  id Int @id @default(autoincrement())
+  user User @relation(fields: [userId], references: [id])
+  userId Int
+  weekStart DateTime
+  plan Json
+  createdAt DateTime @default(now())
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,8 @@ import express from "express";
 import session from "express-session";
 import authRoutes from "./routes/auth";
 import recipeRoutes from "./routes/recipes";
+import generatePlanRoutes from "./routes/generatePlan"
+import groceryRoutes from "./routes/grocery"
 import dotenv from "dotenv";
 
 dotenv.config();
@@ -29,5 +31,7 @@ app.use(
 
 app.use(authRoutes);
 app.use(recipeRoutes);
+app.use(generatePlanRoutes);
+app.use(groceryRoutes);
 
 export default app;

--- a/backend/src/routes/generatePlan.ts
+++ b/backend/src/routes/generatePlan.ts
@@ -1,0 +1,66 @@
+import { Router } from "express";
+import prisma from "../prisma";
+import requireAuth from "../middleware/requireAuth";
+
+const router = Router();
+
+router.post("/generate-plan", requireAuth, async (req, res) => {
+  const username = req.session.user?.username;
+  const { recipePreferences, dailyMeals } = req.body;
+
+  const user = await prisma.user.findUnique({ where: { username } });
+  if (!user) {
+    res.status(401).json({ error: "user not found" });
+    return;
+  }
+  const DAYS = [
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+  ];
+
+  const expanded: { title: string; spoonacularId: number; servings: number }[] = [];
+  for (const r of recipePreferences) {
+    if (r.servings > 0) {
+        expanded.push({ title: r.title, spoonacularId: r.spoonacularId, servings: r.servings });
+    }
+  }
+
+  for (let i = expanded.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [expanded[i], expanded[j]] = [expanded[j], expanded[i]];
+  }
+
+  const plan: {
+    day: string;
+    meals: { title: string; spoonacularId: number; servings: number }[];
+  }[] = [];
+  let index = 0;
+
+  for (const day of DAYS) {
+    const mealCount = dailyMeals[day] || 0;
+    const meals: { title: string; spoonacularId: number; servings: number }[] = [];
+    for (let m = 0; m < mealCount; m++) {
+      if (index >= expanded.length) break;
+      meals.push(expanded[index]);
+      index++;
+    }
+    plan.push({ day, meals });
+  }
+  const weekStart = new Date();
+  weekStart.setHours(0, 0, 0, 0);
+  await prisma.mealPlan.create({
+    data: {
+      userId: user.id,
+      weekStart,
+      plan,
+    },
+  });
+  res.json({ message: "plan generated", plan });
+});
+
+export default router;

--- a/backend/src/routes/grocery.ts
+++ b/backend/src/routes/grocery.ts
@@ -1,0 +1,77 @@
+import { Router } from "express";
+import prisma from "../prisma";
+import requireAuth from "../middleware/requireAuth";
+
+const router = Router();
+const SPOON_KEY = process.env.SPOON_KEY!;
+
+router.get("/grocery", requireAuth, async (req, res) => {
+  const username = req.session.user?.username;
+  const user = await prisma.user.findUnique({
+    where: { username },
+    include: {
+      mealPlans: {
+        orderBy: { createdAt: "desc" },
+        take: 1,
+      },
+    },
+  });
+
+  const mealPlan = user?.mealPlans?.[0];
+
+  if (!mealPlan || !mealPlan.plan) {
+    res.status(404).json({ error: "no generated plan found" });
+    return;
+  }
+
+  const plan = mealPlan.plan as {
+    day: string;
+    meals: { spoonacularId: number; servings: number }[];
+  }[];
+
+  const grouped: Record<
+    string,
+    Record<string, { amount: number; unit: string }>
+  > = {};
+
+  for (const planEntry of plan) {
+    for (const meal of planEntry.meals) {
+      const id = meal.spoonacularId;
+      const userServings = meal.servings ?? 1;
+      const response = await fetch(
+        `https://api.spoonacular.com/recipes/${id}/information?apiKey=${process.env.SPOON_KEY}`
+      );
+      const data = await response.json();
+
+      const recipeServings = data.servings || 1;
+      const multiplier = userServings / recipeServings;
+      for (const ing of data.extendedIngredients) {
+        const key = ing.nameClean?.toLowerCase() || ing.name.toLowerCase();
+        const aisle = ing.aisle || "other";
+        const amount = ing.amount || 1;
+        const unit = ing.unit || "unit";
+        const adjustedAmount = amount * multiplier;
+
+        if (!grouped[aisle]) grouped[aisle] = {};
+
+        if (!grouped[aisle][key]) {
+          grouped[aisle][key] = { amount: 0, unit };
+        }
+        grouped[aisle][key].amount += adjustedAmount;
+      }
+    }
+  }
+
+  const output = Object.entries(grouped).map(([category, ingredients]) => ({
+    category,
+    ingredients: Object.entries(ingredients).map(
+      ([name, { amount, unit }]) => ({
+        name,
+        amount: Math.round(amount * 100) / 100,
+        unit,
+      })
+    ),
+  }));
+  res.json(output);
+});
+export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,8 @@ import PantryView from "./pages/PantryView.tsx";
 import Sidebar from "./components/Sidebar.tsx";
 import RecipeDetail from "./pages/RecipeDetail.tsx";
 import Personalized from "./pages/Personalized.tsx";
+import MealPlanner from "./pages/MealPlanner.tsx";
+import GroceryList from "./pages/GroceryList.tsx";
 
 function App() {
   const [user, setUser] = useState<string | null>(null);
@@ -56,6 +58,8 @@ function App() {
           <Route path="/fridge-view" element={<FridgeView />} />
           <Route path="/pantry-view" element={<PantryView />} />
           <Route path="/personalized" element={<Personalized />} />
+          <Route path="/planner" element={<MealPlanner />} />
+          <Route path="/grocery" element={<GroceryList />} />
         </Routes>
       </main>
     </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -29,6 +29,16 @@ const Sidebar = () => {
         Recs
       </NavLink>
 
+      <NavLink to="/planner" className={getClassName}>
+        <PiNotepadFill className="icon" />
+        Meal Plan
+      </NavLink>
+
+      <NavLink to="/grocery" className={getClassName}>
+        <PiNotepadFill className="icon" />
+        Grocery List
+      </NavLink>
+
       <NavLink to="/profile" className={getClassName}>
         <FaUser className="icon" />
         Profile

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,11 +7,9 @@ body {
 
 /*login*/
 .container {
-  /* max-width: 400px; */
   margin: auto;
   padding: 32px;
   background: white;
-  /* box-shadow: 0 0 10px rgba(0, 0, 0, 1); */
   border-radius: 8px;
 }
 
@@ -96,13 +94,7 @@ input {
   display: block;
 }
 
-.chicken,
-.tomato,
-.onion,
-.lemon,
-.garlic,
-.salt,
-.pepper {
+.ingredient {
   position: absolute;
   background: transparent;
   border: 1px;
@@ -110,13 +102,7 @@ input {
   padding: 0;
 }
 
-.chicken:hover img,
-.tomato:hover img,
-.onion:hover img,
-.lemon:hover img,
-.garlic:hover img,
-.salt:hover img,
-.pepper:hover img {
+.ingredient:hover img{ 
   transform: scale(1.1);
 }
 

--- a/frontend/src/pages/FridgeView.tsx
+++ b/frontend/src/pages/FridgeView.tsx
@@ -29,7 +29,7 @@ const FridgeView = () => {
         {fridgeItems.map((item, index) => (
           <button
             key={index}
-            className={`fridge-item ${item.className}`}
+            className={`ingredient ${item.className}`}
             onClick={() => toggleIngredient(item.name)}
           >
             <img src={item.src} alt={item.name} />

--- a/frontend/src/pages/GroceryList.tsx
+++ b/frontend/src/pages/GroceryList.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import type { GroceryItem } from "../types";
+
+export default function GroceryList() {
+  const [list, setList] = useState<GroceryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch("http://localhost:4000/grocery", {
+        credentials: "include",
+      });
+      const data = await res.json();
+      setList(data);
+      setLoading(false);
+    };
+    load();
+  }, []);
+  if (loading) return <p>loading ...</p>;
+
+  return (
+    <div>
+      <h2>grocery list</h2>
+      {list.length === 0 ? (
+        <p>nothing to buy</p>
+      ) : (
+        list.map((group) => (
+          <div key={group.category}>
+            <h3>{group.category}</h3>
+            <ul>
+              {group.ingredients.map((item) => (
+                <li key={`${group.category}-${item.name}`}>
+                  {item.name}: {item.amount} {item.unit}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/MealPlanner.tsx
+++ b/frontend/src/pages/MealPlanner.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const DAYS = [
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday",
+];
+
+export default function MealPlanner() {
+  const [savedRecipes, setSavedRecipes] = useState<
+    {id: string; title: string}[]>([]);
+
+  const [mealCounts, setMealCounts] = useState<Record<string, number>>(() =>
+    Object.fromEntries(DAYS.map((d) => [d, 3]))
+  );
+
+  const [recipePreferences, setRecipePreferences] = useState<
+    { title: string; spoonacularId: number; servings: number }[]
+  >([]);
+
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState("");
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const loadSaved = async () => {
+        const res = await fetch("http://localhost:4000/recipes/user", {
+            credentials: "include",
+        });
+        const data = await res.json();
+        setSavedRecipes(data);
+        setRecipePreferences(
+            data.map((r: any) => ({
+                title: r.title,
+                spoonacularId: parseInt(r.id),
+                servings: 1,
+            }))
+        );
+        setLoading(false);
+    };
+    loadSaved();
+  }, []);
+
+  const handleGenerate = async () => {
+    const res = await fetch("http://localhost:4000/generate-plan", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ recipePreferences, dailyMeals: mealCounts }),
+    });
+
+    if (res.ok) {
+      setMessage("meal plan generated");
+      navigate("/grocery");
+    } else {
+      setMessage("failed to generate");
+    }
+  };
+
+  if (loading) return <p>loading saved recipes...</p>
+
+  return (
+    <div>
+      <h2>meal planner</h2>
+      <h3>meals per day</h3>
+      {DAYS.map((day) => (
+        <div key={day}>
+          {day}:{" "}
+          <input
+            type="number"
+            value={mealCounts[day]}
+            min={0}
+            max={6}
+            onChange={(e) =>
+              setMealCounts({ ...mealCounts, [day]: +e.target.value })
+            }
+          />
+        </div>
+      ))}
+
+      <h3>recipe preferences</h3>
+      {recipePreferences.length === 0 ? (
+        <p>no saved recipes</p>
+      ) : (
+        recipePreferences.map((r, i) => (
+        <div key={r.spoonacularId}>
+          {r.title}: eat{" "}
+          <input
+            type="number"
+            value={r.servings}
+            min={0}
+            max={10}
+            onChange={(e) => {
+              const updated = [...recipePreferences];
+              updated[i].servings = +e.target.value;
+              setRecipePreferences(updated);
+            }}
+          />{" "}
+          times
+        </div>
+        ))
+      )}
+      <button onClick={handleGenerate}>generate meal plan</button>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/PantryView.tsx
+++ b/frontend/src/pages/PantryView.tsx
@@ -36,7 +36,7 @@ const PantryView = () => {
         {pantryItems.map((item, index) => (
           <button
             key={index}
-            className={`fridge-item ${item.className}`}
+            className={`ingredient ${item.className}`}
             onClick={() => toggleIngredient(item.name)}
           >
             <img src={item.src} alt={item.name} />

--- a/frontend/src/pages/Personalized.tsx
+++ b/frontend/src/pages/Personalized.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 type Recipe = {

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useIngredients } from "../context/IngredientContext";
 import RecipeCard from "../components/RecipeCard";
 import FilterModal from "../components/FilterModal";
@@ -94,6 +94,7 @@ const Recipes = () => {
       params.append("number", "25");
       params.append("addRecipeNutrition", "true");
       params.append("includeIngredients", selected.join(","));
+      params.append("instructionsRequired", "true");
 
       Object.entries(filters).forEach(([key, value]) => {
         if (value.trim()) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,13 @@
+export type GroceryItem = {
+    category: string;
+    ingredients: {
+        name: string;
+        amount: number;
+        unit:string;
+    }[];
+};
+
+export type SpoonacularRecipe = {
+    id: number;
+    title: string;
+}


### PR DESCRIPTION
## Description
- Allows users to create a meal plan based on how many times they want eat each saved recipe, on what days and how many times per day
- Creates a grocery list based on the meal plan 
   - Categorizes the grocery list based on `aisle`
   - Adjusts quantities based on number of servings of that recipe

What will be done in future PRs:
- In the meal plan page, the display will be the current meal plan, so what days they want to eat and what recipes has the meal planner assigned to that day. 
- Integrate nutrition goals target 
- Have a history of previous generated meal plans to reapply for that week 
- Implement a recommended recipe if those nutrition goals are not met (STRETCH)

## Milestones
- This tackles majority of TC1 but there are a lot I still want to integrate cause this is just the skeleton to get the grocery list generated

## Resources
Spoonacular Docs (https://spoonacular.com/food-api/docs)

## Test Plan
https://www.loom.com/share/2442e0020f194cd8aecb7cded8ceffb1?sid=053779a7-bc7f-4f62-91b4-45fceff550ce