### PR TITLE
Normalizing Recipe Score, Recipes Recommended only from top 5 users, Database Caching for Meal Plan

### DIFF
--- a/backend/dist/routes/friendSuggestion.js
+++ b/backend/dist/routes/friendSuggestion.js
@@ -15,28 +15,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("express");
 const prisma_1 = __importDefault(require("../prisma"));
 const requireAuth_1 = __importDefault(require("../middleware/requireAuth"));
-const recipeMap_1 = require("../utils/recipeMap");
+const similarity_1 = require("../utils/similarity");
 const router = (0, express_1.Router)();
-//calculates recipe similarity using weighted jaccard similarity
-//weight: 1 (if saved), 2 (if liked), 3 (if saved and liked)
-function recipeSimilar(mapA, mapB) {
-    const allRecipeIds = new Set([...mapA.keys(), ...mapB.keys()]);
-    let intersection = 0;
-    let union = 0;
-    for (const id of allRecipeIds) {
-        const a = mapA.get(id) || 0;
-        const b = mapB.get(id) || 0;
-        intersection += Math.min(a, b); // both users saved recipes
-        union += Math.max(a, b); //unique recipes
-    }
-    return union === 0 ? 0 : intersection / union;
-}
-//ingredient overlap similarity using jaccard
-function ingredientOverlap(ingredientsA, ingredientsB) {
-    const intersection = new Set([...ingredientsA].filter((ing) => ingredientsB.has(ing)));
-    const union = new Set([...ingredientsA, ...ingredientsB]);
-    return union.size === 0 ? 0 : intersection.size / union.size;
-}
 router.get("/friends/suggestions", requireAuth_1.default, (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     var _a;
     const username = (_a = req.session.user) === null || _a === void 0 ? void 0 : _a.username;
@@ -53,31 +33,18 @@ router.get("/friends/suggestions", requireAuth_1.default, (req, res) => __awaite
             res.status(404).json({ error: "user not found" });
             return;
         }
-        const userIngredients = new Set();
-        const userMap = (0, recipeMap_1.recipeMap)(currUser.saved, currUser.liked, userIngredients);
         const otherUsers = yield prisma_1.default.user.findMany({
             where: { id: { not: currUser.id } },
             include: { saved: true, liked: true },
         });
-        const suggestions = otherUsers
-            .map((user) => {
-            const otherIngredients = new Set();
-            const otherMap = (0, recipeMap_1.recipeMap)(user.saved, user.liked, otherIngredients);
-            //calculating similarity score for both recipe and ingredient based
-            const recipeScore = recipeSimilar(userMap, otherMap);
-            const ingredientScore = ingredientOverlap(userIngredients, otherIngredients);
-            const finalScore = 0.7 * recipeScore + 0.3 * ingredientScore;
-            return {
-                id: user.id,
-                username: user.username,
-                similarity: parseFloat(finalScore.toFixed(2)),
-                recipeScore: parseFloat(recipeScore.toFixed(2)),
-                ingredientScore: parseFloat(ingredientScore.toFixed(2)),
-            };
-        })
-            .filter((s) => s.similarity > 0.1) //filter out users who have little similarity
-            .sort((a, b) => b.similarity - a.similarity) //sort from highest similarity
-            .slice(0, 5); //top 5 users with the highest similarity
+        const topUsers = (0, similarity_1.top5Users)(currUser, otherUsers);
+        const suggestions = topUsers.map(({ user, finalScore, recipeScore, ingredientScore }) => ({
+            id: user.id,
+            username: user.username,
+            similarity: parseFloat(finalScore.toFixed(2)),
+            recipeScore: parseFloat(recipeScore.toFixed(2)),
+            ingredientScore: parseFloat(ingredientScore.toFixed(2)),
+        }));
         res.json(suggestions);
     }
     catch (err) {

--- a/backend/dist/routes/mealPlan.js
+++ b/backend/dist/routes/mealPlan.js
@@ -15,6 +15,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("express");
 const prisma_1 = __importDefault(require("../prisma"));
 const requireAuth_1 = __importDefault(require("../middleware/requireAuth"));
+const nutritionCache_1 = require("../utils/nutritionCache");
 const router = (0, express_1.Router)();
 const SPOON_KEY = process.env.SPOON_KEY;
 router.get("/meal-plan", requireAuth_1.default, (req, res) => __awaiter(void 0, void 0, void 0, function* () {
@@ -46,25 +47,12 @@ router.get("/meal-plan", requireAuth_1.default, (req, res) => __awaiter(void 0, 
         const uniqueId = [...new Set(allMeals.map((m) => m.spoonacularId))];
         //fetch all unique recipe's nutritional data in parallel by sending out multiple async api request using promise.all
         //so instead of waiting n times, it'd just be 1 time
-        const spoonacularRes = yield Promise.all(uniqueId.map((id) => __awaiter(void 0, void 0, void 0, function* () {
-            const response = yield fetch(`https://api.spoonacular.com/recipes/${id}/nutritionWidget.json?apiKey=${SPOON_KEY}`);
-            if (!response.ok) {
-                console.error(`error fetching spoonacular recipe ${id}: `, yield response.text());
-                return null;
-            }
-            const data = yield response.json();
-            return {
-                id,
-                calories: parseInt(data.calories),
-                protein: parseFloat(data.protein.replace("g", "")),
-                carbs: parseFloat(data.carbs.replace("g", "")),
-            };
-        })));
+        const spoonacularRes = yield Promise.all(uniqueId.map((id) => __awaiter(void 0, void 0, void 0, function* () { return (0, nutritionCache_1.nutritionInfo)(id); })));
         //accessing the recipe's nutrition info by id in a map has O(1) time
         const nutritionMap = new Map();
         for (const item of spoonacularRes) {
             if (item) {
-                nutritionMap.set(item.id, {
+                nutritionMap.set(item.spoonacularId, {
                     calories: item.calories,
                     protein: item.protein,
                     carbs: item.carbs,
@@ -112,5 +100,20 @@ router.get("/meal-plan/history", requireAuth_1.default, (req, res) => __awaiter(
         return;
     }
     res.json(user.mealPlans);
+}));
+router.get("/nutrition/:id", requireAuth_1.default, (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const id = parseInt(req.params.id);
+    if (isNaN(id)) {
+        res.status(400).json({ error: "invalid id" });
+        return;
+    }
+    try {
+        const nutrition = yield (0, nutritionCache_1.nutritionInfo)(id);
+        res.json(nutrition);
+    }
+    catch (err) {
+        console.error("nutrition fetch failed: ", err);
+        res.status(500).json({ error: "cannot fetch nutrition" });
+    }
 }));
 exports.default = router;

--- a/backend/dist/routes/recipes.js
+++ b/backend/dist/routes/recipes.js
@@ -16,6 +16,7 @@ const express_1 = require("express");
 const requireAuth_1 = __importDefault(require("../middleware/requireAuth"));
 const prisma_1 = __importDefault(require("../prisma"));
 const recipeMap_1 = require("../utils/recipeMap");
+const similarity_1 = require("../utils/similarity");
 require("express-session");
 const SPOON_KEY = process.env.SPOON_KEY;
 //saving recipes
@@ -352,17 +353,15 @@ router.get("/recipes/recommended", requireAuth_1.default, (req, res) => __awaite
         }
         //current user's interactions
         const userSaved = (0, recipeMap_1.recipeMap)(currUser.saved, currUser.liked);
-        const seenRecipes = new Set();
-        for (const recipeId of userSaved.keys()) {
-            seenRecipes.add(recipeId);
-        }
+        const seenRecipes = new Set(userSaved.keys());
         //other user's interactions
         const otherUsers = yield prisma_1.default.user.findMany({
             where: { id: { not: currUser.id } },
             include: { saved: true, liked: true },
         });
+        const topUsers = (0, similarity_1.top5Users)(currUser, otherUsers);
         const scores = new Map();
-        for (const user of otherUsers) {
+        for (const { user } of topUsers) {
             //map of weights
             const otherSaved = (0, recipeMap_1.recipeMap)(user.saved, user.liked);
             //map of recipeIds and its information (title, ingredients, etc)
@@ -403,7 +402,7 @@ router.get("/recipes/recommended", requireAuth_1.default, (req, res) => __awaite
         }
         const topRecipes = [...scores.values()]
             .map(({ recipe, totalWeighted, numUsers }) => {
-            //make the score consistent by dividing it by the maximum weight (3). total weight can be over 1
+            //make the score consistent by dividing it by the maximum weight (3) * number of users interacted. total weight can be over 1
             //cause there are multiple user scores added together. max the score at 100 even if totalWeighted is over 100
             const denominator = 3 * numUsers.size;
             const percentage = denominator > 0 ? (totalWeighted / denominator) * 100 : 0;

--- a/backend/dist/routes/recipes.js
+++ b/backend/dist/routes/recipes.js
@@ -319,14 +319,14 @@ router.get("/recipes/user/:username", (req, res) => __awaiter(void 0, void 0, vo
 //how much recipes a user has interacted with does not effect the score as it uses magnitude
 function cosineSimilarity(a, b) {
     const allRecipeIds = new Set([...a.keys(), ...b.keys()]);
-    let dot = 0; //
+    let dot = 0;
     let magnitudeA = 0;
     let magnitudeB = 0;
     for (const id of allRecipeIds) {
         const valA = a.get(id) || 0;
         const valB = b.get(id) || 0;
         dot += valA * valB; //calculate how much users interact with the same recipe
-        //overall interaction for that user 
+        //overall interaction for that user
         magnitudeA += valA ** 2;
         magnitudeB += valB ** 2;
     }
@@ -371,7 +371,7 @@ router.get("/recipes/recommended", requireAuth_1.default, (req, res) => __awaite
             for (const recipe of user.saved) {
                 otherRecipe.set(recipe.id, recipe);
             }
-            //adding liked-only recipes that were not saved 
+            //adding liked-only recipes that were not saved
             for (const liked of user.liked) {
                 if (!otherRecipe.has(liked.id)) {
                     otherRecipe.set(liked.id, liked);
@@ -384,26 +384,29 @@ router.get("/recipes/recommended", requireAuth_1.default, (req, res) => __awaite
                 if (seenRecipes.has(recipeId))
                     continue; //skip receipes that the current user has interacted with
                 const existing = scores.get(recipeId);
-                //calculating that specific user's contribution to the recipe score 
+                //calculating that specific user's contribution to the recipe score
                 //user similarity * their weight (1,2,3) for that recipe
                 const totalScore = sim * score;
                 if (existing) {
                     //total of all the score and other user similarities
                     existing.totalWeighted += totalScore;
+                    existing.numUsers.add(user.id.toString());
                 }
                 else {
                     scores.set(recipeId, {
                         recipe: otherRecipe.get(recipeId),
                         totalWeighted: totalScore,
+                        numUsers: new Set([user.id.toString()]),
                     });
                 }
             }
         }
         const topRecipes = [...scores.values()]
-            .map(({ recipe, totalWeighted }) => {
+            .map(({ recipe, totalWeighted, numUsers }) => {
             //make the score consistent by dividing it by the maximum weight (3). total weight can be over 1
             //cause there are multiple user scores added together. max the score at 100 even if totalWeighted is over 100
-            const percentage = Math.min((totalWeighted / 3) * 100, 100);
+            const denominator = 3 * numUsers.size;
+            const percentage = denominator > 0 ? (totalWeighted / denominator) * 100 : 0;
             return Object.assign(Object.assign({}, recipe), { score: parseFloat(percentage.toFixed(2)) });
         })
             .sort((a, b) => b.score - a.score);

--- a/backend/dist/utils/nutritionCache.js
+++ b/backend/dist/utils/nutritionCache.js
@@ -1,0 +1,40 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.nutritionInfo = nutritionInfo;
+const prisma_1 = __importDefault(require("../prisma"));
+const SPOON_KEY = process.env.SPOON_KEY;
+function nutritionInfo(spoonacularId) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const cached = yield prisma_1.default.nutritionCache.findUnique({
+            where: { spoonacularId },
+        });
+        if (cached)
+            return cached;
+        const res = yield fetch(`https://api.spoonacular.com/recipes/${spoonacularId}/nutritionWidget.json?apiKey=${SPOON_KEY}`);
+        const data = yield res.json();
+        const nutrition = {
+            spoonacularId,
+            calories: parseInt(data.calories),
+            protein: parseFloat(data.protein.replace("g", "")),
+            carbs: parseFloat(data.carbs.replace("g", "")),
+        };
+        yield prisma_1.default.nutritionCache.upsert({
+            where: { spoonacularId },
+            update: nutrition,
+            create: nutrition,
+        });
+        return nutrition;
+    });
+}

--- a/backend/dist/utils/similarity.js
+++ b/backend/dist/utils/similarity.js
@@ -1,0 +1,50 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.recipeSimilar = recipeSimilar;
+exports.ingredientOverlap = ingredientOverlap;
+exports.top5Users = top5Users;
+const recipeMap_1 = require("../utils/recipeMap");
+//calculates recipe similarity using weighted jaccard similarity
+//weight: 1 (if saved), 2 (if liked), 3 (if saved and liked)
+function recipeSimilar(mapA, mapB) {
+    const allRecipeIds = new Set([...mapA.keys(), ...mapB.keys()]);
+    let intersection = 0;
+    let union = 0;
+    for (const id of allRecipeIds) {
+        const a = mapA.get(id) || 0;
+        const b = mapB.get(id) || 0;
+        intersection += Math.min(a, b); //min interaction of that recipe
+        union += Math.max(a, b); //max interaction of that recipe
+    }
+    return union === 0 ? 0 : intersection / union;
+}
+//ingredient overlap similarity using jaccard
+function ingredientOverlap(ingredientsA, ingredientsB) {
+    // both users saved ingredients  
+    const intersection = new Set([...ingredientsA].filter((ing) => ingredientsB.has(ing)));
+    //unique recipes
+    const union = new Set([...ingredientsA, ...ingredientsB]);
+    return union.size === 0 ? 0 : intersection.size / union.size;
+}
+function top5Users(currUser, otherUsers) {
+    const userIngredients = new Set();
+    const userMap = (0, recipeMap_1.recipeMap)(currUser.saved, currUser.liked, userIngredients);
+    return otherUsers
+        .map((user) => {
+        const otherIngredients = new Set();
+        const otherMap = (0, recipeMap_1.recipeMap)(user.saved, user.liked, otherIngredients);
+        //calculating similarity score for both recipe and ingredient based
+        const recipeScore = recipeSimilar(userMap, otherMap);
+        const ingredientScore = ingredientOverlap(userIngredients, otherIngredients);
+        const finalScore = 0.7 * recipeScore + 0.3 * ingredientScore;
+        return {
+            user,
+            finalScore,
+            recipeScore,
+            ingredientScore,
+        };
+    })
+        .filter(({ finalScore }) => finalScore > 0.1) //filter out users who have little similarity
+        .sort((a, b) => b.finalScore - a.finalScore) //sort from highest similarity
+        .slice(0, 5); //top 5 users with the highest similarity
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -42,3 +42,11 @@ model MealPlan {
   plan Json
   createdAt DateTime @default(now())
 }
+
+model NutritionCache {
+  spoonacularId Int @id
+  calories Int
+  protein Float
+  carbs Float
+  updatedAt DateTime @updatedAt
+}

--- a/backend/src/routes/friendSuggestion.ts
+++ b/backend/src/routes/friendSuggestion.ts
@@ -2,38 +2,11 @@ import { Router } from "express";
 import prisma from "../prisma";
 import requireAuth from "../middleware/requireAuth";
 import { recipeMap } from "../utils/recipeMap";
+import {
+  top5Users
+} from "../utils/similarity"
 
 const router = Router();
-
-//calculates recipe similarity using weighted jaccard similarity
-//weight: 1 (if saved), 2 (if liked), 3 (if saved and liked)
-function recipeSimilar(
-  mapA: Map<string, number>,
-  mapB: Map<string, number>
-): number {
-  const allRecipeIds = new Set([...mapA.keys(), ...mapB.keys()]);
-  let intersection = 0;
-  let union = 0;
-  for (const id of allRecipeIds) {
-    const a = mapA.get(id) || 0;
-    const b = mapB.get(id) || 0;
-    intersection += Math.min(a, b); // both users saved recipes
-    union += Math.max(a, b); //unique recipes
-  }
-  return union === 0 ? 0 : intersection / union;
-}
-
-//ingredient overlap similarity using jaccard
-function ingredientOverlap(
-  ingredientsA: Set<string>,
-  ingredientsB: Set<string>
-): number {
-  const intersection = new Set(
-    [...ingredientsA].filter((ing) => ingredientsB.has(ing))
-  );
-  const union = new Set([...ingredientsA, ...ingredientsB]);
-  return union.size === 0 ? 0 : intersection.size / union.size;
-}
 
 router.get("/friends/suggestions", requireAuth, async (req, res) => {
   const username = req.session.user?.username;
@@ -53,37 +26,20 @@ router.get("/friends/suggestions", requireAuth, async (req, res) => {
       return;
     }
 
-    const userIngredients = new Set<string>();
-    const userMap = recipeMap(currUser.saved, currUser.liked, userIngredients);
-
     const otherUsers = await prisma.user.findMany({
       where: { id: { not: currUser.id } },
       include: { saved: true, liked: true },
     });
-    const suggestions = otherUsers
-      .map((user) => {
-        const otherIngredients = new Set<string>();
-        const otherMap = recipeMap(user.saved, user.liked, otherIngredients);
 
-        //calculating similarity score for both recipe and ingredient based
-        const recipeScore = recipeSimilar(userMap, otherMap);
-        const ingredientScore = ingredientOverlap(
-          userIngredients,
-          otherIngredients
-        );
-        const finalScore = 0.7 * recipeScore + 0.3 * ingredientScore;
+    const topUsers = top5Users(currUser, otherUsers);
 
-        return {
-          id: user.id,
-          username: user.username,
-          similarity: parseFloat(finalScore.toFixed(2)),
-          recipeScore: parseFloat(recipeScore.toFixed(2)),
-          ingredientScore: parseFloat(ingredientScore.toFixed(2)),
-        };
-      })
-      .filter((s) => s.similarity > 0.1) //filter out users who have little similarity
-      .sort((a, b) => b.similarity - a.similarity) //sort from highest similarity
-      .slice(0, 5); //top 5 users with the highest similarity
+    const suggestions = topUsers.map(({user, finalScore, recipeScore, ingredientScore}) => ({
+      id: user.id,
+      username: user.username,
+      similarity: parseFloat(finalScore.toFixed(2)),
+      recipeScore: parseFloat(recipeScore.toFixed(2)),
+      ingredientScore: parseFloat(ingredientScore.toFixed(2)),
+    }))
 
     res.json(suggestions);
   } catch (err) {

--- a/backend/src/routes/mealPlan.ts
+++ b/backend/src/routes/mealPlan.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import prisma from "../prisma";
 import requireAuth from "../middleware/requireAuth";
+import {nutritionInfo} from "../utils/nutritionCache"
 
 const router = Router();
 const SPOON_KEY = process.env.SPOON_KEY!;
@@ -45,25 +46,7 @@ router.get("/meal-plan", requireAuth, async (req, res) => {
     //fetch all unique recipe's nutritional data in parallel by sending out multiple async api request using promise.all
     //so instead of waiting n times, it'd just be 1 time
     const spoonacularRes = await Promise.all(
-      uniqueId.map(async (id) => {
-        const response = await fetch(
-          `https://api.spoonacular.com/recipes/${id}/nutritionWidget.json?apiKey=${SPOON_KEY}`,
-        );
-        if (!response.ok) {
-          console.error(
-            `error fetching spoonacular recipe ${id}: `,
-            await response.text(),
-          );
-          return null;
-        }
-        const data = await response.json();
-        return {
-          id,
-          calories: parseInt(data.calories),
-          protein: parseFloat(data.protein.replace("g", "")),
-          carbs: parseFloat(data.carbs.replace("g", "")),
-        };
-      }),
+      uniqueId.map(async (id) => nutritionInfo(id))
     );
 
     //accessing the recipe's nutrition info by id in a map has O(1) time
@@ -73,7 +56,7 @@ router.get("/meal-plan", requireAuth, async (req, res) => {
     >();
     for (const item of spoonacularRes) {
       if (item) {
-        nutritionMap.set(item.id, {
+        nutritionMap.set(item.spoonacularId, {
           calories: item.calories,
           protein: item.protein,
           carbs: item.carbs,
@@ -125,4 +108,20 @@ router.get("/meal-plan/history", requireAuth, async (req, res) => {
 
   res.json(user.mealPlans);
 });
+
+router.get("/nutrition/:id", requireAuth, async(req, res) => {
+  const id = parseInt(req.params.id);
+  if (isNaN(id)) {
+    res.status(400).json({error: "invalid id"});
+    return;
+  }
+  try {
+    const nutrition = await nutritionInfo(id);
+    res.json(nutrition);
+  } catch (err) {
+    console.error("nutrition fetch failed: ", err);
+    res.status(500).json({error: "cannot fetch nutrition"});
+  }
+});
+
 export default router;

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import requireAuth from "../middleware/requireAuth";
 import prisma from "../prisma";
 import { recipeMap } from "../utils/recipeMap";
+import { top5Users } from "../utils/similarity";
 
 import "express-session";
 declare module "express-session" {
@@ -393,11 +394,7 @@ router.get("/recipes/recommended", requireAuth, async (req, res) => {
 
     //current user's interactions
     const userSaved = recipeMap(currUser.saved, currUser.liked);
-    const seenRecipes = new Set<string>();
-
-    for (const recipeId of userSaved.keys()) {
-      seenRecipes.add(recipeId);
-    }
+    const seenRecipes = new Set(userSaved.keys());
 
     //other user's interactions
     const otherUsers = await prisma.user.findMany({
@@ -405,12 +402,14 @@ router.get("/recipes/recommended", requireAuth, async (req, res) => {
       include: { saved: true, liked: true },
     });
 
+    const topUsers = top5Users(currUser, otherUsers);
+
     const scores: Map<
       string,
       { recipe: any; totalWeighted: number; numUsers: Set<string> }
     > = new Map();
 
-    for (const user of otherUsers) {
+    for (const { user } of topUsers) {
       //map of weights
       const otherSaved = recipeMap(user.saved, user.liked);
       //map of recipeIds and its information (title, ingredients, etc)

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from "express";
 import requireAuth from "../middleware/requireAuth";
 import prisma from "../prisma";
-import {recipeMap} from "../utils/recipeMap";
+import { recipeMap } from "../utils/recipeMap";
 
 import "express-session";
 declare module "express-session" {
@@ -358,7 +358,7 @@ function cosineSimilarity(
   b: Map<string, number>
 ): number {
   const allRecipeIds = new Set([...a.keys(), ...b.keys()]);
-  let dot = 0; //
+  let dot = 0;
   let magnitudeA = 0;
   let magnitudeB = 0;
 
@@ -366,9 +366,9 @@ function cosineSimilarity(
     const valA = a.get(id) || 0;
     const valB = b.get(id) || 0;
     dot += valA * valB; //calculate how much users interact with the same recipe
-    //overall interaction for that user 
-    magnitudeA += valA ** 2; 
-    magnitudeB += valB ** 2; 
+    //overall interaction for that user
+    magnitudeA += valA ** 2;
+    magnitudeB += valB ** 2;
   }
   if (magnitudeA === 0 || magnitudeB === 0) return 0;
   return dot / (Math.sqrt(magnitudeA) * Math.sqrt(magnitudeB)); //final similarity score (closer to 1 more similar they are)
@@ -407,7 +407,7 @@ router.get("/recipes/recommended", requireAuth, async (req, res) => {
 
     const scores: Map<
       string,
-      { recipe: any; totalWeighted: number }
+      { recipe: any; totalWeighted: number; numUsers: Set<string> }
     > = new Map();
 
     for (const user of otherUsers) {
@@ -421,7 +421,7 @@ router.get("/recipes/recommended", requireAuth, async (req, res) => {
         otherRecipe.set(recipe.id, recipe);
       }
 
-      //adding liked-only recipes that were not saved 
+      //adding liked-only recipes that were not saved
       for (const liked of user.liked) {
         if (!otherRecipe.has(liked.id)) {
           otherRecipe.set(liked.id, liked);
@@ -435,26 +435,30 @@ router.get("/recipes/recommended", requireAuth, async (req, res) => {
         if (seenRecipes.has(recipeId)) continue; //skip receipes that the current user has interacted with
 
         const existing = scores.get(recipeId);
-        //calculating that specific user's contribution to the recipe score 
+        //calculating that specific user's contribution to the recipe score
         //user similarity * their weight (1,2,3) for that recipe
-        const totalScore = sim * score; 
+        const totalScore = sim * score;
 
         if (existing) {
           //total of all the score and other user similarities
           existing.totalWeighted += totalScore;
+          existing.numUsers.add(user.id.toString());
         } else {
           scores.set(recipeId, {
             recipe: otherRecipe.get(recipeId),
             totalWeighted: totalScore,
+            numUsers: new Set([user.id.toString()]),
           });
         }
       }
     }
     const topRecipes = [...scores.values()]
-      .map(({ recipe, totalWeighted }) => {
-        //make the score consistent by dividing it by the maximum weight (3). total weight can be over 1
+      .map(({ recipe, totalWeighted, numUsers }) => {
+        //make the score consistent by dividing it by the maximum weight (3) * number of users interacted. total weight can be over 1
         //cause there are multiple user scores added together. max the score at 100 even if totalWeighted is over 100
-        const percentage = Math.min((totalWeighted / 3) * 100, 100);
+        const denominator = 3 * numUsers.size;
+        const percentage =
+          denominator > 0 ? (totalWeighted / denominator) * 100 : 0;
         return {
           ...recipe,
           score: parseFloat(percentage.toFixed(2)),

--- a/backend/src/utils/nutritionCache.ts
+++ b/backend/src/utils/nutritionCache.ts
@@ -1,0 +1,29 @@
+import prisma from "../prisma";
+
+const SPOON_KEY = process.env.SPOON_KEY!;
+
+export async function nutritionInfo(spoonacularId: number) {
+  const cached = await prisma.nutritionCache.findUnique({
+    where: {spoonacularId},
+  })
+
+  if (cached) return cached;
+
+  const res = await fetch(
+    `https://api.spoonacular.com/recipes/${spoonacularId}/nutritionWidget.json?apiKey=${SPOON_KEY}`
+  );
+  const data = await res.json();
+
+  const nutrition = {
+    spoonacularId,
+    calories: parseInt(data.calories),
+    protein: parseFloat(data.protein.replace("g", "")),
+    carbs: parseFloat(data.carbs.replace("g", "")),
+  }
+  await prisma.nutritionCache.upsert({
+    where: {spoonacularId},
+    update: nutrition,
+    create: nutrition,
+  });
+  return nutrition;
+}

--- a/backend/src/utils/similarity.ts
+++ b/backend/src/utils/similarity.ts
@@ -1,0 +1,60 @@
+import { recipeMap } from "../utils/recipeMap";
+
+//calculates recipe similarity using weighted jaccard similarity
+//weight: 1 (if saved), 2 (if liked), 3 (if saved and liked)
+export function recipeSimilar(
+  mapA: Map<string, number>,
+  mapB: Map<string, number>
+): number {
+  const allRecipeIds = new Set([...mapA.keys(), ...mapB.keys()]);
+  let intersection = 0;
+  let union = 0;
+  for (const id of allRecipeIds) {
+    const a = mapA.get(id) || 0;
+    const b = mapB.get(id) || 0;
+    intersection += Math.min(a, b); // both users saved recipes
+    union += Math.max(a, b); //unique recipes
+  }
+  return union === 0 ? 0 : intersection / union;
+}
+
+//ingredient overlap similarity using jaccard
+export function ingredientOverlap(
+  ingredientsA: Set<string>,
+  ingredientsB: Set<string>
+): number {
+  const intersection = new Set(
+    [...ingredientsA].filter((ing) => ingredientsB.has(ing))
+  );
+  const union = new Set([...ingredientsA, ...ingredientsB]);
+  return union.size === 0 ? 0 : intersection.size / union.size;
+}
+
+export function top5Users(currUser: any, otherUsers: any[]) {
+  const userIngredients = new Set<string>();
+  const userMap = recipeMap(currUser.saved, currUser.liked, userIngredients);
+
+  return otherUsers
+    .map((user) => {
+      const otherIngredients = new Set<string>();
+      const otherMap = recipeMap(user.saved, user.liked, otherIngredients);
+
+      //calculating similarity score for both recipe and ingredient based
+      const recipeScore = recipeSimilar(userMap, otherMap);
+      const ingredientScore = ingredientOverlap(
+        userIngredients,
+        otherIngredients
+      );
+      const finalScore = 0.7 * recipeScore + 0.3 * ingredientScore;
+
+      return {
+        user,
+        finalScore,
+        recipeScore,
+        ingredientScore,
+      };
+    })
+    .filter(({ finalScore }) => finalScore > 0.1) //filter out users who have little similarity
+    .sort((a, b) => b.finalScore - a.finalScore) //sort from highest similarity
+    .slice(0, 5); //top 5 users with the highest similarity
+}

--- a/backend/src/utils/similarity.ts
+++ b/backend/src/utils/similarity.ts
@@ -12,8 +12,8 @@ export function recipeSimilar(
   for (const id of allRecipeIds) {
     const a = mapA.get(id) || 0;
     const b = mapB.get(id) || 0;
-    intersection += Math.min(a, b); // both users saved recipes
-    union += Math.max(a, b); //unique recipes
+    intersection += Math.min(a, b); //min interaction of that recipe
+    union += Math.max(a, b); //max interaction of that recipe
   }
   return union === 0 ? 0 : intersection / union;
 }
@@ -23,9 +23,11 @@ export function ingredientOverlap(
   ingredientsA: Set<string>,
   ingredientsB: Set<string>
 ): number {
+  // both users saved ingredients  
   const intersection = new Set(
     [...ingredientsA].filter((ing) => ingredientsB.has(ing))
   );
+  //unique recipes
   const union = new Set([...ingredientsA, ...ingredientsB]);
   return union.size === 0 ? 0 : intersection.size / union.size;
 }

--- a/frontend/src/pages/MealPlanner.tsx
+++ b/frontend/src/pages/MealPlanner.tsx
@@ -32,10 +32,6 @@ export default function MealPlanner() {
 
   const [nutrition, setNutrition] = useState<any | null>(null);
   const [adjusted, setAdjusted] = useState(false);
-  //cache nutrition data for recipes
-  const [nutritionCache, setNutritionCache] = useState<
-    Map<Number, { calories: number; protein: number; carbs: number }>
-  >(new Map());
   const [goals, setGoals] = useState({
     calories: 2000,
     protein: 200,
@@ -121,22 +117,12 @@ export default function MealPlanner() {
     //fetch nutrition info, but use cache first if its possible
     await Promise.all(
       updatedPreference.map(async (r) => {
-        const cached = nutritionCache.get(r.spoonacularId);
-        if (cached) {
-          nutritionMap.set(r.spoonacularId, cached);
-          return;
-        }
         const res = await fetch(
-          `https://api.spoonacular.com/recipes/${r.spoonacularId}/nutritionWidget.json?apiKey=${SPOON_KEY}`
-        );
+          `${backendURL}/nutrition/${r.spoonacularId}`, {
+            credentials: "include"
+          });
         const data = await res.json();
-        const parsed = {
-          calories: parseInt(data.calories),
-          protein: parseFloat(data.protein.replace("g", "")),
-          carbs: parseFloat(data.carbs.replace("g", "")),
-        };
-        nutritionMap.set(r.spoonacularId, parsed);
-        setNutritionCache((prev) => new Map(prev).set(r.spoonacularId, parsed));
+        nutritionMap.set(r.spoonacularId, data);
       })
     );
 


### PR DESCRIPTION
## Description
- Normalizing recipe match score by 3 * (number of users who interacted with it) instead of just 3
  - This makes the match score more true to how the other users interacted with this recipe rather than just dividing it by 3, because we would have to cap it at 100%
- Made it so that the recommended recipes are only from the top 5 users suggested by the friend algorithm 
  - Makes it even more dynamic as the recommended recipes would only come from users who are the 5 most similar to the current user
- Implemented database caching for a recipe's nutrition information to limit API calls    

## Milestones
TC1: Grocery List
TC2: User Suggestion Algorithm
Code Organization

## Resources
Cache - https://expertbeacon.com/the-complete-guide-to-local-storage-caching-objects-arrays-and-more/, https://stackoverflow.com/questions/12227752/what-is-a-database-cache-and-how-does-one-use-it, https://www.prisma.io/dataguide/managing-databases/introduction-database-caching, https://www.geeksforgeeks.org/dbms/what-is-caching-strategies-in-dbms/, https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage, https://developer.mozilla.org/en-US/docs/Web/API/Window/caches

## Test Plan
